### PR TITLE
Add a ; to help GitHub syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub type User {
     name: String,
     age: Int
   )
-}
+};
 
 // Second, we define a decoder that will decode an Elixir User struct and
 // transform it into our custom Gleam type.


### PR DESCRIPTION
When pretending that Gleam is Rust to get syntax highlighting it can help to add semicolons after custom type definitions, otherwise GitHub can get confused and stop highlighting.