### PR TITLE
Gleam 0.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,18 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp: [22.1]
+        gleam: [0.11.2, 0.12.1, 0.13.2, 0.14.0]
     steps:
       - uses: actions/checkout@v2.0.0
       - uses: gleam-lang/setup-erlang@v1.1.0
         with:
-          otp-version: 22.1
+          otp-version: ${{matrix.otp}}
       - uses: gleam-lang/setup-gleam@v1.0.1
         with:
-          gleam-version: 0.11.2
+          gleam-version: ${{matrix.gleam}}
       - run: rebar3 install_deps
       - run: rebar3 eunit
       - run: gleam format --check src test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         otp: [23.2]
-        gleam: [0.11.2, 0.12.1, 0.13.2, 0.14.0]
+        gleam: [0.12.1, 0.13.2, 0.14.0]
     steps:
       - uses: actions/checkout@v2.0.0
       - uses: gleam-lang/setup-erlang@v1.1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [22.1]
+        otp: [23.2]
         gleam: [0.11.2, 0.12.1, 0.13.2, 0.14.0]
     steps:
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         gleam: [0.11.2, 0.12.1, 0.13.2, 0.14.0]
     steps:
       - uses: actions/checkout@v2.0.0
-      - uses: gleam-lang/setup-erlang@v1.1.0
+      - uses: gleam-lang/setup-erlang@v1.1.2
         with:
           otp-version: ${{matrix.otp}}
       - uses: gleam-lang/setup-gleam@v1.0.1

--- a/rebar.config
+++ b/rebar.config
@@ -8,5 +8,5 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "< 0.15"}
+    {gleam_stdlib, "~> 0.11"}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -8,5 +8,5 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "0.11.0"}
+    {gleam_stdlib, "< 0.15"}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 {"1.2.0",
-[{<<"gleam_stdlib">>,{pkg,<<"gleam_stdlib">>,<<"0.11.0">>},0}]}.
+[{<<"gleam_stdlib">>,{pkg,<<"gleam_stdlib">>,<<"0.14.0">>},0}]}.
 [
 {pkg_hash,[
- {<<"gleam_stdlib">>, <<"9B1089739574CDF78A1C25A463D770A98F59E63A92324D17095AD67E867EE549">>}]},
+ {<<"gleam_stdlib">>, <<"765D90AC06F97D7A8E8F7AC4BEDA373879D98C78A27FD8DEACC98AA34DA2DDCE">>}]},
 {pkg_hash_ext,[
- {<<"gleam_stdlib">>, <<"5508E169E20369FC8D400481D3F37CCB2CFD880509F63D6E2B6D85F939BC991B">>}]}
+ {<<"gleam_stdlib">>, <<"9107F6A859CB96945AD9A099085DB028CA2BEBB3C8EA42EEC227B51C614CC2E0">>}]}
 ].

--- a/test/decode_test.gleam
+++ b/test/decode_test.gleam
@@ -193,7 +193,7 @@ pub fn then_and_from_result_test() {
 type ForeignFunctionResult {
   Success(Int)
   Failure(String)
-  Error
+  Err
 }
 
 pub fn ok_error_tuple_test() {
@@ -202,7 +202,7 @@ pub fn ok_error_tuple_test() {
 
   let decode_foreign_function_result = fn(result: Dynamic) {
     decode_dynamic(result, ok_error_tuple(ok_decoder, error_decoder))
-    |> result_mod.unwrap(Error)
+    |> result_mod.unwrap(Err)
   }
 
   let ok_atom = atom_mod.create_from_string("ok")
@@ -218,10 +218,10 @@ pub fn ok_error_tuple_test() {
   |> decode_foreign_function_result
   |> should.equal(Failure("Something went predictably wrong!"))
 
-  // A decoding error becomes an Error record (variant) of the
+  // A decoding error becomes an Err record (variant) of the
   // ForeignFunctionResult type
   ["Uh oh.", "Something went unpredictably wrong!"]
   |> dynamic_mod.from
   |> decode_foreign_function_result
-  |> should.equal(Error)
+  |> should.equal(Err)
 }


### PR DESCRIPTION
Looks like `gleam_decode` should work on the latest Gleam version.

Changes in this PR:

- Make Gleam dependency less strict
- Tweak tests to fix compilation errors on the latest Gleam version
- Run Github workflow on all supported Gleam versions